### PR TITLE
implements OnchainReceive handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 
 [[package]]
 name = "cfg-if"
@@ -409,9 +409,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -952,6 +952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,10 +1448,10 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -1454,10 +1469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
- "multimap",
+ "multimap 0.10.0",
  "once_cell",
  "petgraph",
  "prettyplease 0.2.20",
@@ -1475,7 +1490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1488,7 +1503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.68",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,11 +1,11 @@
 use clap::{Parser, Subcommand};
 use client::ServerHackClient;
-use protos::GetNodeStatusRequest;
+use protos::{GetNodeStatusRequest, OnchainReceiveRequest};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {
-	#[arg(short, long)]
+	#[arg(short, long, default_value = "localhost:3000")]
 	base_url: String,
 
 	#[command(subcommand)]
@@ -15,6 +15,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
 	NodeStatus {},
+	NewAddress {},
 }
 
 #[tokio::main]
@@ -30,6 +31,16 @@ async fn main() {
 				},
 				Err(e) => {
 					eprintln!("Error getting node status: {:?}", e);
+				},
+			};
+		},
+		Commands::NewAddress {} => {
+			match client.get_new_funding_address(OnchainReceiveRequest {}).await {
+				Ok(address) => {
+					println!("New address: {:?}", address);
+				},
+				Err(e) => {
+					eprintln!("Error getting new funding address: {:?}", e);
 				},
 			};
 		},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 
 use crate::error::ServerHackError;
 use prost::Message;
-use protos::{GetNodeStatusRequest, GetNodeStatusResponse};
+use protos::{GetNodeStatusRequest, GetNodeStatusResponse, OnchainReceiveRequest};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 
@@ -23,6 +23,13 @@ impl ServerHackClient {
 		&self, request: GetNodeStatusRequest,
 	) -> Result<GetNodeStatusResponse, ServerHackError> {
 		let url = format!("http://{}/status", self.base_url);
+		self.post_request(&request, &url).await
+	}
+
+	pub async fn get_new_funding_address(
+		&self, request: OnchainReceiveRequest,
+	) -> Result<OnchainReceiveRequest, ServerHackError> {
+		let url = format!("http://{}//onchain/receive", self.base_url);
 		self.post_request(&request, &url).await
 	}
 


### PR DESCRIPTION
* Implements `OnChainReceive` handler to return new wallet address
* Implements `new-address` cli subcommand
   * Adds default for `--base-url` flag (localhost:3000)

```
$ ./cli new-address                                 
New address: OnchainRecevieResponse { address: "bcrt1q4hqgcw8t73chwdr6g4knzpufrq0rlg9ta8wy7l" }
```