### PR TITLE
Remove protoc installs from Dockerfile and GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
-      - name: Install build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
       - name: Install Rust ${{ matrix.toolchain }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ matrix.toolchain }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Use the latest version of the Rust base image
 FROM rust:latest
 
-# Install build tools
-RUN apt-get update && apt-get install -y \
-    protobuf-compiler
-
 # Set the working directory in the container to /my
 WORKDIR /usr/src/ldk-node-hack-server
 


### PR DESCRIPTION
Since we removed tonic we no longer need this dependency