### PR TITLE
Enable dummy LSP mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     build: .
     ports:
       - "3000:3000"
+      - "9735:9735"
     networks:
       - bitcoin-electrs
 

--- a/docker-config.json
+++ b/docker-config.json
@@ -1,6 +1,6 @@
 {
     "esplora_server_url": "http://electrs:3002",
-    "listening_addr": "localhost:9735",
+    "listening_addr": "0.0.0.0:9735",
     "log_level": "trace",
     "network": "regtest",
     "rest_service_addr": "0.0.0.0:3000",

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
 	node.start_with_runtime(Arc::clone(&runtime)).unwrap();
 
 	println!("CONNECTION_STRING: {}@{}", node.node_id(), config.listening_addr.to_string());
+	println!("FUNDING ADDRESS: {}", node.onchain_payment().new_address().unwrap());
 
 	runtime.block_on(async {
 		let mut sigterm_stream = match tokio::signal::unix::signal(SignalKind::terminate()) {


### PR DESCRIPTION
This enables the LSP mode. (Confirmed we can retrieve a JIT invoice)

We also expose a few more ports which enables local testing.