### PR TITLE
Display human readable error on decode failures

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -2,7 +2,7 @@ use prost::DecodeError;
 
 #[derive(Debug)]
 pub enum ServerHackError {
-	FailedRequest(reqwest::StatusCode, Vec<u8>),
+	FailedRequest(reqwest::StatusCode, String),
 	InternalError(String),
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -79,10 +79,17 @@ impl ServerHackClient {
 		let payload = response_raw.bytes().await?;
 
 		if status.is_success() {
-			let response = Rs::decode(&payload[..])?;
-			Ok(response)
+			Rs::decode(&payload[..]).map_err(|_| {
+				ServerHackError::FailedRequest(
+					reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+					String::from_utf8(payload.to_vec()).unwrap(),
+				)
+			})
 		} else {
-			Err(ServerHackError::FailedRequest(status, payload.to_vec()))
+			Err(ServerHackError::FailedRequest(
+				status,
+				String::from_utf8(payload.to_vec()).unwrap(),
+			))
 		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where if you use the wrong route in the client, the server returns b"UNKNOWN REQUEST" and then the client tries to decode these bytes into the expected response proto, which fails. This change allows us to see the error message from the server