### PR TITLE
Add basic service integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Check formatting
         if: matrix.check-fmt
         run: rustup component add rustfmt && cargo fmt --all -- --check
-      - name: Test on Rust ${{ matrix.toolchain }}
+      - name: Unit test on Rust ${{ matrix.toolchain }}
         run: cargo test
+      - name: Integration tests on Rust ${{ matrix.toolchain }}
+        run: cargo test  -- --ignored
       - name: Cargo check release on Rust ${{ matrix.toolchain }}
         run: cargo check --release
       - name: Cargo check doc on Rust ${{ matrix.toolchain }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM rust:latest
 WORKDIR /usr/src/ldk-node-hack-server
 
 # Copy the Rust project files to the working directory
-COPY server/ server/
+COPY server/src server/src
+COPY server/Cargo.toml server/Cargo.toml
 COPY Cargo.toml .
 COPY docker-config.json .
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -130,7 +130,7 @@ async fn main() {
 			};
 		},
 		Commands::PaymentsHistory => {
-			match client.get_payments_history(&PaymentsHistoryRequest {}).await {
+			match client.get_payments_history(PaymentsHistoryRequest {}).await {
 				Ok(response) => {
 					println!("Payments history: {:?}", response);
 				},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -90,10 +90,10 @@ impl ServerHackClient {
 	}
 
 	pub async fn get_payments_history(
-		&self, request: &PaymentsHistoryRequest,
+		&self, request: PaymentsHistoryRequest,
 	) -> Result<PaymentsHistoryResponse, ServerHackError> {
 		let url = format!("http://{}/{PAYMENTS_HISTORY_PATH}", self.base_url);
-		self.post_request(request, &url).await
+		self.post_request(&request, &url).await
 	}
 
 	pub async fn get_payment_details(

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -6,12 +6,15 @@ pushd cli
 cargo run -- --base-url localhost:3000 node-id
 cargo run -- --base-url localhost:3000 node-status
 cargo run -- --base-url localhost:3000 new-address
-cargo run -- --base-url localhost:3000 send-onchain addy 1000
+# Currently fails due to insufficient funds
+cargo run -- --base-url localhost:3000 send-onchain bcrt1qcupfx8l06ads2ej9n3h7gcvpc3lhnm8708xawy 1000
 cargo run -- --base-url localhost:3000 bolt11-receive "description" 1000 1000
 cargo run -- --base-url localhost:3000 node-balances
 cargo run -- --base-url localhost:3000 payments-history
-cargo run -- --base-url localhost:3000 payment-details -p 12345678901234567890123456789012
+# Payment id is invalid, need to get a legit one from bolt11-send
+cargo run -- --base-url localhost:3000 payment-details -p bfb1737ad6a575e44be343d73da4655e36ddea8c1a4479522e22f054a80705be
 cargo run -- --base-url localhost:3000 list-channels
+# Currently fails due to insufficient funds
 cargo run -- --base-url localhost:3000 open-channel --node-id 027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190 --address localhost:3042 --channel-amount-sats 1000000 --announce-channel
 cargo run -- --base-url localhost:3000 close-channel --user-channel-id 1234567890123456 --counterparty-node-id 027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190
 cargo run -- --base-url localhost:3000 force-close-channel --user-channel-id 1234567890123456 --counterparty-node-id 027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190

--- a/server/tests/docker_compose.rs
+++ b/server/tests/docker_compose.rs
@@ -1,0 +1,142 @@
+use std::error;
+use std::fmt;
+use std::{
+	collections::HashMap,
+	path::PathBuf,
+	process::{Command, Output},
+};
+
+#[derive(Debug)]
+pub enum DockerComposeError {
+	Spawn(std::io::Error),
+	Wait(std::io::Error),
+	ExitStatus(std::process::ExitStatus),
+}
+
+impl fmt::Display for DockerComposeError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(self, f)
+	}
+}
+
+impl error::Error for DockerComposeError {}
+
+#[derive(Debug)]
+pub struct DockerComposeConfig {
+	pub compose_file: PathBuf,
+	pub env: HashMap<String, String>,
+	pub project_name: String,
+}
+
+pub struct DockerCompose {
+	config: DockerComposeConfig,
+}
+
+impl DockerCompose {
+	fn base_cmd(config: &DockerComposeConfig) -> Command {
+		let mut cmd = Command::new("docker");
+		cmd.arg("compose");
+		cmd.arg("--file");
+		cmd.arg(&config.compose_file);
+		cmd.arg("--project-name");
+		cmd.arg(&config.project_name);
+		cmd.envs(&config.env);
+		cmd
+	}
+
+	fn up_cmd(config: &DockerComposeConfig) -> Command {
+		let mut cmd = DockerCompose::base_cmd(config);
+		cmd.arg("up");
+		cmd.arg("--wait");
+		cmd.arg("--timeout");
+		cmd.arg("5");
+		cmd
+	}
+
+	fn down_cmd(config: &DockerComposeConfig) -> Command {
+		let mut cmd = DockerCompose::base_cmd(config);
+		cmd.arg("down");
+		cmd.arg("--volumes");
+		cmd.arg("--rmi");
+		cmd.arg("local");
+		cmd.arg("--timeout");
+		cmd.arg("5");
+		cmd
+	}
+
+	fn restart_cmd(config: &DockerComposeConfig, service: &str) -> Command {
+		let mut cmd = DockerCompose::base_cmd(config);
+		cmd.arg("restart");
+		cmd.arg("--timeout");
+		cmd.arg("10");
+		cmd.arg(service);
+		cmd
+	}
+
+	fn logs_cmd(config: &DockerComposeConfig) -> Command {
+		let mut cmd = DockerCompose::base_cmd(config);
+		cmd.arg("logs");
+		cmd
+	}
+
+	fn run(mut cmd: Command) -> Result<(), DockerComposeError> {
+		print!("Running command {:?}", cmd);
+		cmd.spawn()
+			.map_err(DockerComposeError::Spawn)
+			.and_then(|mut h| h.wait().map_err(DockerComposeError::Wait))
+			.and_then(|status| {
+				if status.success() {
+					Ok(())
+				} else {
+					Err(DockerComposeError::ExitStatus(status))
+				}
+			})
+	}
+
+	#[allow(dead_code)]
+	fn run_with_output(mut cmd: Command) -> Result<Output, DockerComposeError> {
+		print!("Running command {:?}", cmd);
+		cmd.output().map_err(DockerComposeError::Spawn)
+	}
+
+	#[allow(dead_code)]
+	pub fn up_with_output(
+		config: DockerComposeConfig,
+	) -> Result<(DockerCompose, Output), DockerComposeError> {
+		print!("Starting docker compose with {:?}", config);
+		let cmd = DockerCompose::up_cmd(&config);
+		DockerCompose::run_with_output(cmd).map(|o| (DockerCompose { config }, o))
+	}
+
+	pub fn up(config: DockerComposeConfig) -> Result<DockerCompose, DockerComposeError> {
+		print!("Starting docker compose with {:?}", config);
+		let cmd = DockerCompose::up_cmd(&config);
+		DockerCompose::run(cmd).map(|e| DockerCompose { config })
+	}
+
+	pub fn restart(&self, service: &str) -> Result<(), DockerComposeError> {
+		print!("Restarting docker compose container {} with {:?}", service, self.config);
+		let cmd = DockerCompose::restart_cmd(&self.config, service);
+		DockerCompose::run(cmd)
+	}
+
+	fn down(&self) -> Result<(), DockerComposeError> {
+		let cmd = DockerCompose::down_cmd(&self.config);
+		DockerCompose::run(cmd)
+	}
+
+	fn logs(&self) -> Result<(), DockerComposeError> {
+		let cmd = DockerCompose::logs_cmd(&self.config);
+		DockerCompose::run(cmd)
+	}
+}
+
+impl Drop for DockerCompose {
+	fn drop(&mut self) {
+		if std::thread::panicking() {
+			self.logs().expect("Could not run docker compose logs");
+		}
+		eprintln!("Dropping docker compose");
+		self.down().expect("Could not run docker compose down");
+	}
+}

--- a/server/tests/test_service.rs
+++ b/server/tests/test_service.rs
@@ -1,0 +1,157 @@
+/// Integration tests for the service module.
+/// Intentionally ignored as they require starting the servers which is slow.
+/// Run with `cargo test --test test_service -- --ignored`
+mod docker_compose;
+
+use std::{collections::HashMap, ptr::addr_of, sync::Once};
+
+use client::ServerHackClient;
+use docker_compose::{DockerCompose, DockerComposeConfig};
+use protos::{
+	Bolt11ReceiveRequest, CloseChannelRequest, ForceCloseChannelRequest, GetBalancesRequest,
+	GetNodeIdRequest, GetNodeStatusRequest, GetPaymentDetailsRequest, ListChannelsRequest,
+	OnchainReceiveRequest, OnchainSendRequest, OpenChannelRequest, PaymentsHistoryRequest,
+};
+
+const SERVER_URL: &str = "localhost:3000";
+const COMPOSE_FILE_PATH: &str = "../docker-compose.yml";
+
+const GET_NODE_ID_PATH: &str = "getNodeId";
+const GET_NODE_STATUS_PATH: &str = "getNodeStatus";
+const ONCHAIN_RECEIVE: &str = "onchain/receive";
+const ONCHAIN_SEND: &str = "onchain/send";
+const BOLT11_RECEIVE: &str = "bolt11/receive";
+const GET_NODE_BALANCES_PATH: &str = "getNodeBalances";
+const PAYMENTS_HISTORY_PATH: &str = "listPaymentsHistory";
+const GET_PAYMENT_DETAILS_PATH: &str = "getPaymentDetails";
+const LIST_CHANNELS_PATH: &str = "channel/list";
+const OPEN_CHANNEL_PATH: &str = "channel/open";
+const CLOSE_CHANNEL_PATH: &str = "channel/close";
+const FORCE_CLOSE_CHANNEL_PATH: &str = "channel/force-close";
+
+fn start_docker_compose() -> DockerCompose {
+	let (docker_compose, _) = DockerCompose::up_with_output(DockerComposeConfig {
+		compose_file: COMPOSE_FILE_PATH.into(),
+		env: HashMap::new(),
+		project_name: "integration-tests".to_string(),
+	})
+	.inspect(|(_, output)| {
+		println!("docker-compose output: {output:?}");
+	})
+	.inspect_err(|e| {
+		eprintln!("Error starting docker-compose: {e:?}");
+	})
+	.unwrap();
+	docker_compose
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_service_endpoints_dont_fail_with_sample_requests() {
+	// Doing this in one test for now to easily start the servers once.
+	// Can use something like once_cell later to split the tests up.
+	// For now the tests do not interfere with each other but they probably would
+	// with some actual testing of expected output.
+	let docker_compose = start_docker_compose();
+
+	let client = ServerHackClient::new(SERVER_URL.to_string());
+
+	node_status_request(&client).await;
+	get_node_id(&client).await;
+	let address = onchain_receive(&client).await;
+	// Failing with "The available funds are insufficient to complete the given operation.""
+	// onchain_send(&client, address).await;
+	bolt11_receive(&client).await;
+	get_node_balances(&client).await;
+	get_payments_history(&client).await;
+	// Need bolt11_send to get a payment id
+	// get_payment_details(&client, payment_id).await
+	list_channels(&client).await;
+	// Need functionality to add funds to open channels first
+	// let channel_id = open_channel(&client).await;
+	// close_channel(&client, channel_id.clone()).await;
+	// force_close_channel(&client, channel_id).await;
+
+	drop(docker_compose);
+}
+
+async fn node_status_request(client: &ServerHackClient) {
+	let request = GetNodeStatusRequest {};
+	client.get_node_status(request).await.unwrap();
+}
+
+async fn get_node_id(client: &ServerHackClient) {
+	let request = GetNodeIdRequest {};
+	client.get_node_id(request).await.unwrap();
+}
+
+async fn onchain_receive(client: &ServerHackClient) -> String {
+	let request = OnchainReceiveRequest {};
+	let response = client.get_new_funding_address(request).await.unwrap();
+	response.address
+}
+
+async fn onchain_send(client: &ServerHackClient, address: String) {
+	let request = OnchainSendRequest { address, amount_sats: Some(10_000) };
+	client.send_onchain(request).await.unwrap();
+}
+
+async fn bolt11_receive(client: &ServerHackClient) {
+	let request = Bolt11ReceiveRequest {
+		description: "description".to_string(),
+		expiry_secs: 10,
+		amount_msat: Some(10_000),
+	};
+	client.bolt11_receive(request).await.unwrap();
+}
+
+async fn get_node_balances(client: &ServerHackClient) {
+	let request = GetBalancesRequest {};
+	client.get_node_balances(request).await.unwrap();
+}
+
+async fn get_payments_history(client: &ServerHackClient) {
+	let request = PaymentsHistoryRequest {};
+	client.get_payments_history(request).await.unwrap();
+}
+
+async fn get_payment_details(client: &ServerHackClient, payment_id: String) {
+	// To get a valid payment id, use bolt11_recieve to get and invoice and then bolt11_send to that invoice .
+	let request = GetPaymentDetailsRequest { payment_id };
+	client.get_payment_details(request).await.unwrap();
+}
+
+async fn list_channels(client: &ServerHackClient) {
+	let request = ListChannelsRequest {};
+	client.list_channels(request).await.unwrap();
+}
+
+async fn open_channel(client: &ServerHackClient) -> Vec<u8> {
+	let request = OpenChannelRequest {
+		node_id: "027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190".to_string(),
+		address: "localhost:3042".to_string(),
+		channel_amount_sats: 100_000,
+		push_to_counterparty_msat: None,
+		announce_channel: true,
+	};
+	let response = client.open_channel(request).await.unwrap();
+	response.user_channel_id
+}
+
+async fn close_channel(client: &ServerHackClient, channel_id: Vec<u8>) {
+	let request = CloseChannelRequest {
+		user_channel_id: channel_id,
+		counterparty_node_id: "027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190"
+			.to_string(),
+	};
+	client.close_channel(request).await.unwrap();
+}
+
+async fn force_close_channel(client: &ServerHackClient, channel_id: Vec<u8>) {
+	let request = ForceCloseChannelRequest {
+		user_channel_id: channel_id,
+		counterparty_node_id: "027100442c3b79f606f80f322d98d499eefcb060599efc5d4ecb00209c2cb54190"
+			.to_string(),
+	};
+	client.force_close_channel(request).await.unwrap();
+}

--- a/server/tests/test_service.rs
+++ b/server/tests/test_service.rs
@@ -3,6 +3,7 @@
 /// Run with `cargo test --test test_service -- --ignored`
 mod docker_compose;
 
+use core::panic;
 use std::{collections::HashMap, ptr::addr_of, sync::Once};
 
 use client::ServerHackClient;
@@ -16,33 +17,20 @@ use protos::{
 const SERVER_URL: &str = "localhost:3000";
 const COMPOSE_FILE_PATH: &str = "../docker-compose.yml";
 
-const GET_NODE_ID_PATH: &str = "getNodeId";
-const GET_NODE_STATUS_PATH: &str = "getNodeStatus";
-const ONCHAIN_RECEIVE: &str = "onchain/receive";
-const ONCHAIN_SEND: &str = "onchain/send";
-const BOLT11_RECEIVE: &str = "bolt11/receive";
-const GET_NODE_BALANCES_PATH: &str = "getNodeBalances";
-const PAYMENTS_HISTORY_PATH: &str = "listPaymentsHistory";
-const GET_PAYMENT_DETAILS_PATH: &str = "getPaymentDetails";
-const LIST_CHANNELS_PATH: &str = "channel/list";
-const OPEN_CHANNEL_PATH: &str = "channel/open";
-const CLOSE_CHANNEL_PATH: &str = "channel/close";
-const FORCE_CLOSE_CHANNEL_PATH: &str = "channel/force-close";
-
 fn start_docker_compose() -> DockerCompose {
-	let (docker_compose, _) = DockerCompose::up_with_output(DockerComposeConfig {
+	match DockerCompose::up_with_output(DockerComposeConfig {
 		compose_file: COMPOSE_FILE_PATH.into(),
 		env: HashMap::new(),
 		project_name: "integration-tests".to_string(),
-	})
-	.inspect(|(_, output)| {
-		println!("docker-compose output: {output:?}");
-	})
-	.inspect_err(|e| {
-		eprintln!("Error starting docker-compose: {e:?}");
-	})
-	.unwrap();
-	docker_compose
+	}) {
+		Ok((docker_compose, output)) => {
+			println!("docker-compose output: {output:?}");
+			docker_compose
+		},
+		Err(e) => {
+			panic!("Error starting docker-compose: {e:?}");
+		},
+	}
 }
 
 #[tokio::test]


### PR DESCRIPTION
Basic integration testing setup. Starts docker compose once and sends some sample requests using the client to check for panics. Currently, not all endpoints can be tested. For example, we need to have a way to add funds to the wallet before we can test basic channel open requests